### PR TITLE
Added spinup-destroy.yml workflow

### DIFF
--- a/.github/workflows/spinup-destroy.yml
+++ b/.github/workflows/spinup-destroy.yml
@@ -1,0 +1,67 @@
+name: Configure Azure environment
+
+on:
+  pull_request:
+    types: [labeled]
+
+env:
+  IMAGE_REGISTRY_URL: ghcr.io
+  AZURE_RESOURCE_GROUP: cd-with-actions
+  AZURE_APP_PLAN: actions-ttt-deployment
+  AZURE_LOCATION: '"East US"'
+  ###############################################
+  ### Replace <username> with GitHub username ###
+  ###############################################
+  AZURE_WEBAPP_NAME: <username>-ttt-app
+
+jobs:
+  setup-up-azure-resources:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'spin up environment')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Create Azure resource group
+        if: success()
+        run: |
+          az group create --location ${{env.AZURE_LOCATION}} --name ${{env.AZURE_RESOURCE_GROUP}} --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
+
+      - name: Create Azure app service plan
+        if: success()
+        run: |
+          az appservice plan create --resource-group ${{env.AZURE_RESOURCE_GROUP}} --name ${{env.AZURE_APP_PLAN}} --is-linux --sku F1 --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
+
+      - name: Create webapp resource
+        if: success()
+        run: |
+          az webapp create --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --plan ${{ env.AZURE_APP_PLAN }} --name ${{ env.AZURE_WEBAPP_NAME }}  --deployment-container-image-name nginx --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
+
+      - name: Configure webapp to use GHCR
+        if: success()
+        run: |
+          az webapp config container set --docker-custom-image-name nginx --docker-registry-server-password ${{secrets.CR_PAT}} --docker-registry-server-url https://${{env.IMAGE_REGISTRY_URL}} --docker-registry-server-user ${{github.actor}} --name ${{ env.AZURE_WEBAPP_NAME }} --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
+
+  destroy-azure-resources:
+    runs-on: ubuntu-latest
+
+    if: contains(github.event.pull_request.labels.*.name, 'destroy environment')
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Destroy Azure environment
+        if: success()
+        run: |
+          az group delete --name ${{env.AZURE_RESOURCE_GROUP}} --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}} --yes

--- a/.github/workflows/spinup-destroy.yml
+++ b/.github/workflows/spinup-destroy.yml
@@ -12,7 +12,7 @@ env:
   ###############################################
   ### Replace <username> with GitHub username ###
   ###############################################
-  AZURE_WEBAPP_NAME: <username>-ttt-app
+  AZURE_WEBAPP_NAME: AndreyFromNoventiq-ttt-app
 
 jobs:
   setup-up-azure-resources:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow file named `spinup-destroy.yml`. The workflow is designed to manage Azure resources, specifically to create and destroy an Azure environment based on the labels attached to a pull request. The environment includes an Azure resource group, app service plan, and a webapp resource. The workflow is triggered when a pull request is labeled, and it checks for the labels 'spin up environment' or 'destroy environment' to decide whether to create or destroy Azure resources, respectively.

Main changes include:

* [`.github/workflows/spinup-destroy.yml`](diffhunk://#diff-cd24f1ea59354b2c567ef0ccdd69ca0c41b3c68a841d2eb9bdff3e18fcdf74adR1-R67): Added a new GitHub Actions workflow that is triggered on pull requests when they are labeled. It sets up or destroys Azure resources based on the label. The workflow includes two jobs: `setup-up-azure-resources` and `destroy-azure-resources`. The setup job is executed if the pull request is labeled with 'spin up environment', and the destroy job is executed if the pull request is labeled with 'destroy environment'. The Azure resources that are managed include a resource group, an app service plan, and a webapp resource. The workflow uses the Azure login action for authentication and the Azure CLI for managing the resources.